### PR TITLE
remove the generic min/maxTechLevelToBuild restrictions

### DIFF
--- a/Source/ICantFixThat/Main.cs
+++ b/Source/ICantFixThat/Main.cs
@@ -90,16 +90,20 @@ public static class Main
         }
 
         var entDef = thingDef as BuildableDef;
-        if (entDef.minTechLevelToBuild != TechLevel.Undefined &&
-            Faction.OfPlayer.def.techLevel < entDef.minTechLevelToBuild)
+        // If no research needed, block by tech level, otherwise block by IsResearchFinished.
+        if (entDef.researchPrerequisites == null)
         {
-            return false;
-        }
+            if (entDef.minTechLevelToBuild != TechLevel.Undefined &&
+                Faction.OfPlayer.def.techLevel < entDef.minTechLevelToBuild)
+            {
+                return false;
+            }
 
-        if (entDef.maxTechLevelToBuild != TechLevel.Undefined &&
-            Faction.OfPlayer.def.techLevel > entDef.maxTechLevelToBuild)
-        {
-            return false;
+            if (entDef.maxTechLevelToBuild != TechLevel.Undefined &&
+                Faction.OfPlayer.def.techLevel > entDef.maxTechLevelToBuild)
+            {
+                return false;
+            }
         }
 
         return entDef.IsResearchFinished && Find.Storyteller.difficulty.AllowedToBuild(entDef);


### PR DESCRIPTION
This breaks e.g. harp. It for some reason has minTechLevelToBuild set (a bug?), but it's actually made at a forge, so it perfectly possible for tribals to research and "build" it.

Since all vanilla items with minTechLevelToBuild have also a research requirement (with the exception with a horseshoes pin, which is really just a stick), it should be sufficient to rely just on research. Better err on the safe side.
